### PR TITLE
remove cython

### DIFF
--- a/org.openshot.OpenShot.yaml
+++ b/org.openshot.OpenShot.yaml
@@ -146,17 +146,6 @@ modules:
         url: https://github.com/unittest-cpp/unittest-cpp/releases/download/v2.0.0/unittest-cpp-2.0.0.tar.gz
         sha256: 1d1b118518dc200e6b87bbf3ae7bfd00a0cfc6be708255f98e5e3d627a7c9f98
 
-  - name: cython
-    buildsystem: simple
-    build-commands:
-      - python3 setup.py install --prefix=/app
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz
-        sha256: e57acb89bd55943c8d8bf813763d20b9099cc7165c0f16b707631a7654be9cad
-
   - name: pyzmq
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
it's part of the freedesktop 20.08 runtime